### PR TITLE
Fix JS script output quoting in dashboard

### DIFF
--- a/admin/dashboard.php
+++ b/admin/dashboard.php
@@ -192,7 +192,8 @@ echo '</form></div></div>';
 echo '</div>'; // end wrap
 
 // JavaScript for tab switching
-echo '<script>
+$script = <<<EOT
+<script>
 function showTab(tab) {
     document.querySelectorAll(".tab-content").forEach(c => c.classList.add("hidden"));
     document.querySelectorAll(".tab-btn").forEach(b => b.classList.remove("text-blue-600", "font-medium"));
@@ -200,17 +201,19 @@ function showTab(tab) {
     document.getElementById("tab-" + tab).classList.add("text-blue-600", "font-medium");
 }
 function toggleEditForm(id) {
-    document.getElementById('edit-row-' + id).classList.toggle('hidden');
+    document.getElementById("edit-row-" + id).classList.toggle("hidden");
 }
 function addClientFields() {
-    const container = document.getElementById('clients-container');
-    const fields = document.querySelector('.client-fields');
+    const container = document.getElementById("clients-container");
+    const fields = document.querySelector(".client-fields");
     container.appendChild(fields.cloneNode(true));
 }
 function toggleMeetingType() {
-    const type = document.getElementById('meeting_type').value;
-    document.getElementById('location-field').classList.toggle('hidden', type !== 'offline');
-    document.getElementById('link-field').classList.toggle('hidden', type !== 'online');
+    const type = document.getElementById("meeting_type").value;
+    document.getElementById("location-field").classList.toggle("hidden", type !== "offline");
+    document.getElementById("link-field").classList.toggle("hidden", type !== "online");
 }
 showTab("add"); // default tab
-</script>';
+</script>
+EOT;
+echo $script;


### PR DESCRIPTION
## Summary
- escape JS script output in `admin/dashboard.php` using heredoc to avoid PHP parse error

## Testing
- `php -l hilton-lawyer-plugin.php`
- `php -l includes/hooks.php`
- `php -l admin/dashboard.php`
- `php -l includes/install.php`
- `php -l includes/email-functions.php`
- `php -l includes/graph-handler.php`
- `php -l templates/emails/meeting-invite.php`


------
https://chatgpt.com/codex/tasks/task_e_6849839f2efc832abbb31b7d16376466